### PR TITLE
Fixed typo for Set-CscAzureDataLakeStoreACL documentation

### DIFF
--- a/src/ResourceManager/DataLakeStore/Commands.DataLakeStore/help/Set-AzureRmDataLakeStoreItemAcl.md
+++ b/src/ResourceManager/DataLakeStore/Commands.DataLakeStore/help/Set-AzureRmDataLakeStoreItemAcl.md
@@ -26,7 +26,7 @@ The **Set-AzureRmDataLakeStoreItemAcl** cmdlet modifies the access control list 
 
 ### Example 1: Set the ACL for a file and a folder
 ```
-PS C:\>$ACL = Get-AzureRmDataLakeStoreItemAcl -AccountName "ContosoADL" -Path /
+PS C:\>$ACL = Get-AzureRmDataLakeStoreItemAclEntry -AccountName "ContosoADL" -Path /
 PS C:\> Set-AzureRmDataLakeStoreItemAcl -AccountName "ContosoADL" -Path "/MyFiles/Test.txt" -Acl $ACL
 ```
 
@@ -35,7 +35,7 @@ The second command sets the ACL for the file Test.txt to the one in $ACL.
 
 ### Example 2: Set the ACL for folder recursively
 ```
-PS C:\>$ACL = Get-AzureRmDataLakeStoreItemAcl -AccountName "ContosoADL" -Path /Folder1
+PS C:\>$ACL = Get-AzureRmDataLakeStoreItemAclEntry -AccountName "ContosoADL" -Path /Folder1
 PS C:\> Set-AzureRmDataLakeStoreItemAcl -AccountName "ContosoADL" -Path "/Folder2" -Acl $ACL -Recurse -Concurrency 128
 ```
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Fixed typo for Set-CscAzureDataLakeStoreACL documentation.  In the documentation examples, the cmdlet `Get-AzureRmDataLakeStoreItemAcl` was listed, but does not exist.

## Checklist

- [X] I have read the [_Submitting Changes_](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md)
- [X] The title of the PR is clear and informative
- [X] The appropriate [change log has been updated](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#updating-the-change-log)
- [X] The PR does not introduce [breaking changes](https://github.com/Azure/azure-powershell/blob/preview/documentation/breaking-changes/breaking-changes-definition.md)
- [X] If applicable, the changes made in the PR have proper test coverage
- [X] For public API changes to cmdlets:
    - [X] the changes have gone through a [cmdlet design review](https://github.com/Azure/azure-powershell-cmdlet-review-pr)
    - [X] the cmdlet markdown files were [generated using the `platyPS` module](https://github.com/Azure/azure-powershell/blob/preview/documentation/development-docs/help-generation.md)
